### PR TITLE
Add misrc_capture Windows build workflow with libhsdaoh fixes

### DIFF
--- a/.github/workflows/misrc_capture_build.yml
+++ b/.github/workflows/misrc_capture_build.yml
@@ -1,0 +1,165 @@
+name: "Build Windows Release"
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "misrc_capture-*"
+
+env:
+  ARCHIVE_NAME_WINDOWS: ${{ github.ref_name }}-win-x86_64.zip
+
+jobs:
+  build-windows:
+    name: Build Windows
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Install MSVC
+        uses: ilammy/msvc-dev-cmd@v1
+
+      - name: Install NASM
+        env:
+          WINDOWS_NASM_URL: https://www.nasm.us/pub/nasm/releasebuilds/2.16.01/win64/nasm-2.16.01-win64.zip
+          WINDOWS_NASM_DIR: nasm-2.16.01
+        run: |
+          Invoke-WebRequest ${{ env.WINDOWS_NASM_URL }} -OutFile .\nasm.zip
+          Expand-Archive .\nasm.zip -DestinationPath .
+          Write-Output .\${{ env.WINDOWS_NASM_DIR }} | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+      - name: Install FLAC v1.5.0
+        env:
+          FLAC_URL: https://github.com/xiph/flac/releases/download/1.5.0/flac-1.5.0-win.zip
+          FLAC_DIR: flac-1.5.0-win
+        run: |
+          Invoke-WebRequest ${{ env.FLAC_URL }} -OutFile .\flac.zip
+          Expand-Archive .\flac.zip -DestinationPath .
+          # Set environment variables for CMake to find FLAC
+          Write-Output "FLAC_ROOT=${{ github.workspace }}\${{ env.FLAC_DIR }}" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          Write-Output "${{ github.workspace }}\${{ env.FLAC_DIR }}\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+      - name: Install libusb and build libhsdaoh
+        run: |
+          # Download libusb for Windows
+          Invoke-WebRequest "https://github.com/libusb/libusb/releases/download/v1.0.27/libusb-1.0.27.7z" -OutFile .\libusb.7z
+          7z x .\libusb.7z -o.\libusb
+          
+          # Find libusb files dynamically
+          $libusbIncludePath = Get-ChildItem .\libusb -Recurse -Name "libusb.h" | Select-Object -First 1
+          $libusbLibPath = Get-ChildItem .\libusb -Recurse -Name "libusb-1.0.lib" | Select-Object -First 1
+          
+          if ($libusbIncludePath) {
+            $libusbInclude = Split-Path (Join-Path .\libusb $libusbIncludePath) -Parent
+            Write-Host "Found libusb.h at: $libusbInclude"
+          } else {
+            Write-Error "libusb.h not found"
+            exit 1
+          }
+          
+          if ($libusbLibPath) {
+            $libusbLib = Split-Path (Join-Path .\libusb $libusbLibPath) -Parent
+            Write-Host "Found libusb-1.0.lib at: $libusbLib"
+          } else {
+            Write-Error "libusb-1.0.lib not found"
+            exit 1
+          }
+          
+          # Clone and build libhsdaoh
+          git clone https://github.com/Stefan-Olt/hsdaoh.git .\hsdaoh_src
+          
+          # Configure and build hsdaoh
+          cmake -B .\hsdaoh_build -S .\hsdaoh_src `
+            -G "Visual Studio 17 2022" `
+            -A x64 `
+            -DLIBUSB_INCLUDE_DIRS="$libusbInclude" `
+            -DLIBUSB_LIBRARIES="$libusbLib\libusb-1.0.lib" `
+            -DCMAKE_C_FLAGS="/I`"$libusbInclude`"" `
+            -DCMAKE_CXX_FLAGS="/I`"$libusbInclude`""
+          
+          cmake --build .\hsdaoh_build --config Release
+          
+          # Create dependencies directory
+          New-Item -ItemType Directory -Path .\hsdaoh_deps -Force
+          
+          # Copy built files
+          if (Test-Path ".\hsdaoh_build\Release\hsdaoh.dll") {
+            Copy-Item .\hsdaoh_build\Release\hsdaoh.dll .\hsdaoh_deps\
+          }
+          if (Test-Path ".\hsdaoh_build\Release\hsdaoh.lib") {
+            Copy-Item .\hsdaoh_build\Release\hsdaoh.lib .\hsdaoh_deps\
+          }
+          
+          # Copy libusb DLL
+          $libusbDll = Get-ChildItem .\libusb -Recurse -Name "libusb-1.0.dll" | Select-Object -First 1
+          if ($libusbDll) {
+            Copy-Item (Join-Path .\libusb $libusbDll) .\hsdaoh_deps\
+          }
+          
+          # Set environment for main build
+          Write-Output "HSDAOH_ROOT=${{ github.workspace }}\hsdaoh_deps" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          Write-Output "${{ github.workspace }}\hsdaoh_deps" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+      - name: Download pcm_extract v1.0.0
+        run: |
+          Invoke-WebRequest "https://github.com/namazso/pcm_extract/releases/download/v1.0.0/pcm_extract.exe" -OutFile .\pcm_extract.exe
+
+      - name: Build
+        run: |
+          cmake -B ${{ github.workspace }}\misrc_tools/build `
+            ${{ github.workspace }}\misrc_tools `
+            -G "Visual Studio 17 2022" `
+            -A x64
+          # Build both misrc_capture and misrc_extract
+          cmake --build ${{ github.workspace }}\misrc_tools/build --target misrc_capture --config Release
+          cmake --build ${{ github.workspace }}\misrc_tools/build --target misrc_extract --config Release
+
+      - name: Create binary archive
+        run: |
+          # Create a temporary directory for bundling
+          New-Item -ItemType Directory -Path .\bundle -Force
+          
+          # Copy main executables
+          Copy-Item ${{ github.workspace }}\misrc_tools\build\Release\misrc_capture.exe .\bundle\
+          Copy-Item ${{ github.workspace }}\misrc_tools\build\Release\misrc_extract.exe .\bundle\
+          
+          # Copy pcm_extract.exe
+          if (Test-Path ".\pcm_extract.exe") {
+            Copy-Item .\pcm_extract.exe .\bundle\
+          }
+          
+          # Copy FLAC executables and DLLs
+          if (Test-Path "${{ github.workspace }}\flac-1.5.0-win\bin") {
+            $flacBin = "${{ github.workspace }}\flac-1.5.0-win\bin"
+            # FLAC executables
+            if (Test-Path "$flacBin\flac.exe") { Copy-Item "$flacBin\flac.exe" .\bundle\ }
+            if (Test-Path "$flacBin\metaflac.exe") { Copy-Item "$flacBin\metaflac.exe" .\bundle\ }
+            # FLAC DLLs
+            if (Test-Path "$flacBin\libFLAC.dll") { Copy-Item "$flacBin\libFLAC.dll" .\bundle\ }
+            if (Test-Path "$flacBin\libFLAC++.dll") { Copy-Item "$flacBin\libFLAC++.dll" .\bundle\ }
+            if (Test-Path "$flacBin\libogg-0.dll") { Copy-Item "$flacBin\libogg-0.dll" .\bundle\ }
+          }
+          
+          # Copy hsdaoh dependencies
+          if (Test-Path ".\hsdaoh_deps") {
+            Get-ChildItem .\hsdaoh_deps -Filter "*.dll" | ForEach-Object {
+              Copy-Item $_.FullName .\bundle\
+            }
+            Get-ChildItem .\hsdaoh_deps -Filter "*.exe" | ForEach-Object {
+              Copy-Item $_.FullName .\bundle\
+            }
+          }
+          
+          # Create the archive with all files
+          Compress-Archive -Path .\bundle\* -DestinationPath ${{ env.ARCHIVE_NAME_WINDOWS }}
+
+      - name: Upload binary artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: misrc_capture-windows
+          path: ${{ env.ARCHIVE_NAME_WINDOWS }}
+          if-no-files-found: error


### PR DESCRIPTION
- Create new workflow specifically for misrc_capture builds
- Add dynamic libusb path discovery to fix missing header errors
- Include proper CMake flags for libusb include paths
- Keep workflow structure simple and clean